### PR TITLE
Print the full status, output and errors if an install fails

### DIFF
--- a/lib/alces/forge/cli_utils.rb
+++ b/lib/alces/forge/cli_utils.rb
@@ -82,7 +82,17 @@ module Alces
             write_logs(working_dir, cmd, stdout, stderr)
 
             unless status.success?
-              raise ShellException.new(stderr)
+              raise ShellException.new <<-EOF
+The following command exited with status: #{status}
+cd #{working_dir} && #{cmd}
+---------------------------------------------------
+STDOUT:
+#{stdout}
+---------------------------------------------------
+STDERR:
+#{stderr}
+---------------------------------------------------
+EOF
             end
             stdout
           end


### PR DESCRIPTION
Previously very little was being given about why the install has failed. This should give a few more details