### PR TITLE
Rename all the env vars to be shorter

### DIFF
--- a/bin/forge-periodic
+++ b/bin/forge-periodic
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-ENV['BUNDLE_GEMFILE'] ||= "#{ENV['FLIGHT_DIRECT_ROOT']}/opt/forge/Gemfile"
-$: << "#{ENV['FLIGHT_DIRECT_ROOT']}/opt/forge/lib"
+ENV['BUNDLE_GEMFILE'] ||= "#{ENV['FL_ROOT']}/opt/forge/Gemfile"
+$: << "#{ENV['FL_ROOT']}/opt/forge/lib"
 
 require 'bundler/setup'
 require 'alces/forge/tasks/install_marked_packages'

--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.0.1'
+        program :version, '0.1.0'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/cli_utils.rb
+++ b/lib/alces/forge/cli_utils.rb
@@ -4,7 +4,7 @@ require 'open3'
 module Alces
   module Forge
     module CLIUtils
-      LOG_FILE = File.join(ENV['FLIGHT_DIRECT_ROOT'], 'var/log/forge.log')
+      LOG_FILE = File.join(ENV['FL_ROOT'], 'var/log/forge.log')
 
       class ShellException < RuntimeError
       end
@@ -28,7 +28,7 @@ module Alces
         end
 
         def with_spinner(&block)
-          if !tty? || ENV['FLIGHT_DIRECT_NO_SPINNER']
+          if !tty? || ENV['FL_NO_SPINNER']
             block.call
           else
             begin

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -41,10 +41,10 @@ module Alces
 
         DEFAULT_CONFIG = {
             default_user: 'alces',
-            package_cache_dir: "#{ENV['FLIGHT_DIRECT_ROOT']}/var/forge/cache/packages"
+            package_cache_dir: "#{ENV['FL_ROOT']}/var/forge/cache/packages"
         }
 
-        CONFIG_DIRECTORY = "#{ENV['FLIGHT_DIRECT_ROOT']}/etc/forge"
+        CONFIG_DIRECTORY = "#{ENV['FL_ROOT']}/etc/forge"
         CONFIG_FILE_PATH = "#{CONFIG_DIRECTORY}/config.yml"
 
         def config

--- a/lib/alces/forge/registry.rb
+++ b/lib/alces/forge/registry.rb
@@ -8,7 +8,7 @@ module Alces
       # The registry records packages that have been selected for installation, either on the master node or compute nodes
       # (or both); and also packages that have actually been installed on the local node.
 
-      REGISTRY_DIR = "#{ENV['FLIGHT_DIRECT_ROOT']}/var/forge/registers"
+      REGISTRY_DIR = "#{ENV['FL_ROOT']}/var/forge/registers"
       MASTER_REGISTRY_PATH = File.join(REGISTRY_DIR, 'master.yml')
       LOCAL_REGISTRY_PATH = File.join(REGISTRY_DIR, 'local.yml')
 

--- a/libexec/actions/forge
+++ b/libexec/actions/forge
@@ -26,6 +26,6 @@
 #==============================================================================
 # vim: set filetype=sh :
 
-forge_dir=$FLIGHT_DIRECT_ROOT/opt/forge
+forge_dir=$FL_ROOT/opt/forge
 cd $forge_dir && bin/forge "$@"
 


### PR DESCRIPTION
`FLIGHT_DIRECT` is god damn to long! So it has been shortened to `FL`. This makes the env vars shorter overall. It is being done now before a version is properly released.

This update is being coordinated with the main flight direct repo.