### PR TITLE
Allow forge to install packages without users

### DIFF
--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -89,7 +89,8 @@ module Alces
       end
 
       def download_cache_path
-        File.join(Config.package_cache_dir, @metadata.username, @metadata.name)
+        username = @metadata.username || 'Unknown Package'
+        File.join(Config.package_cache_dir, username, @metadata.name)
       end
 
       def download_cache_file


### PR DESCRIPTION
This is quite useful during development

When installing from a local source, the username isn't always set.
This causes the install to fail, which is rather annoying.

Instead these packages are flagged as unknown.