### PR TITLE
Set the api url using the FlightConfig value

### DIFF
--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.1'
+        program :version, '0.1.2'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -30,11 +30,11 @@ module Alces
         end
 
         def api_url
-          ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1'
+          ENV['FL_CONFIG_FORGE_API_URL'] || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1'
         end
 
         def sso_url
-          ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
+          ENV['FL_CONFIG_FORGE_SSO_URL'] || ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
         end
 
         private

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -30,11 +30,11 @@ module Alces
         end
 
         def api_url
-          ENV['FL_CONFIG_FORGE_API_URL'] || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1'
+          File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1') || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com'
         end
 
         def sso_url
-          ENV['FL_CONFIG_FORGE_SSO_URL'] || ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
+          ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
         end
 
         private


### PR DESCRIPTION
The problem with the `cw_FORGE_API_URL` is that it requires the anvil version to be set at the end of the URL. This makes it hard to serve static files on the same server as it is not a simple case of appending the file path.

Instead forge has been updated to use the `FL_CONFIG_CACHE_URL` which does not require the version number. It also shared by the `FlightSyncer` and thus cuts down the configuration required.