### PR TITLE
Fix bug when `FL_CONFIG_CACHE_URL` is missing

### DIFF
--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.2'
+        program :version, '0.1.3'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -30,7 +30,11 @@ module Alces
         end
 
         def api_url
-          File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1') || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com'
+          if ENV['FL_CONFIG_CACHE_URL']
+            File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1')
+          else
+            ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com'
+          end
         end
 
         def sso_url


### PR DESCRIPTION
If the env var is missing, it will try and join it anyway which breaks
forge. Instead, check if it is set first