### PR TITLE
Make the forge command a ROOT only tool

### DIFF
--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.3'
+        program :version, '0.1.4'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/libexec/actions/forge
+++ b/libexec/actions/forge
@@ -1,7 +1,6 @@
 : '
-: NAME: forge
 : SYNOPSIS: Install packages to Flight Direct
-: VERSION: 1.0.0
+: ROOT: true
 : '
 #==============================================================================
 # Copyright (C) 2018 Stephen F. Norledge and Alces Software Ltd.


### PR DESCRIPTION
Currently forge can only be used by the root user and thus should be
hidden by default

Also removed the obsolete VERSION and NAME from the command declaration