### PR TITLE
Always append the api version to the base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ https://github.com/alces-software/flight-direct
 
 Flight Direct uses an Omnibus software config to build forge into its CLI.
 To update the `forge` version in `flight`:
-1. Create a GitHub tag of the new version of `forge-cli`
-2. Update the default version in flight-direct `config/software/forge.rb`
-3. Rebuild flight direct (refer to its repo for details)
+1. Bump the version number in `lib/alces/forge/cli.rb`
+2. Create a GitHub tag of the new version of `forge-cli`
+3. Update the default version in flight-direct `config/software/forge.rb`
+4. Rebuild flight direct (refer to its repo for details)
 

--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.4'
+        program :version, '0.2.0'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -4,6 +4,8 @@ require 'yaml'
 module Alces
   module Forge
     class Config
+      API_VERSION = 'v1'
+
       include Singleton
 
       class << self
@@ -30,11 +32,11 @@ module Alces
         end
 
         def api_url
-          if ENV['FL_CONFIG_CACHE_URL']
-            File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1')
-          else
-            ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1/'
-          end
+          base = ENV['FL_CONFIG_CACHE_URL'] || \
+                 ENV['cw_FORGE_API_URL'] || \
+                 config[:api_url] || \
+                 'https://forge-api.alces-flight.com/'
+          File.join(base, API_VERSION)
         end
 
         def sso_url


### PR DESCRIPTION
The change made to fix #11 meant that both the `FL_CONFIG_CACHE_URL` and default url have the api version appended to it. However `config[:api_url]` and `cw_FORGE_API_URL` are used in there raw form and do not append the version number.

The version number has been built into the Anvil API and is required by all requests. It will only be bumped if there is a breaking change to the API. This makes the `forge-cli` coupled to the version number and thus it should not be set externally.

Instead, the `API_VERSION` will be appended to all the base URL for the reason above and constancy.

This does consitute a breaking change and thus the version number has been bumped. It will not effect existing `flight-direct` installations as they already appended the version implicitly. Regardless, a breaking change was required to fix issue #11