### PR TITLE
Merge the default API version change into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ https://github.com/alces-software/flight-direct
 1. Install the required gems: `bundle install`
 1. Then run the forge-cli directly: `bin/forge`
 
+## Releasing with Flight Direct
+
+Flight Direct uses an Omnibus software config to build forge into its CLI.
+To update the `forge` version in `flight`:
+1. Create a GitHub tag of the new version of `forge-cli`
+2. Update the default version in flight-direct `config/software/forge.rb`
+3. Rebuild flight direct (refer to its repo for details)
+

--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.3'
+        program :version, '0.1.4'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.2'
+        program :version, '0.1.3'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.1.1'
+        program :version, '0.1.2'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -30,7 +30,11 @@ module Alces
         end
 
         def api_url
-          File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1') || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com'
+          if ENV['FL_CONFIG_CACHE_URL']
+            File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1')
+          else
+            ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com'
+          end
         end
 
         def sso_url

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -30,11 +30,11 @@ module Alces
         end
 
         def api_url
-          ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1'
+          ENV['FL_CONFIG_FORGE_API_URL'] || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1'
         end
 
         def sso_url
-          ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
+          ENV['FL_CONFIG_FORGE_SSO_URL'] || ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
         end
 
         private

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -30,11 +30,11 @@ module Alces
         end
 
         def api_url
-          ENV['FL_CONFIG_FORGE_API_URL'] || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com/v1'
+          File.join(ENV['FL_CONFIG_CACHE_URL'], 'v1') || ENV['cw_FORGE_API_URL'] || config[:api_url] || 'https://forge-api.alces-flight.com'
         end
 
         def sso_url
-          ENV['FL_CONFIG_FORGE_SSO_URL'] || ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
+          ENV['cw_FORGE_SSO_URL'] || config[:sso_url] || 'https://accounts.alces-flight.com'
         end
 
         private

--- a/libexec/actions/forge
+++ b/libexec/actions/forge
@@ -1,7 +1,6 @@
 : '
-: NAME: forge
 : SYNOPSIS: Install packages to Flight Direct
-: VERSION: 1.0.0
+: ROOT: true
 : '
 #==============================================================================
 # Copyright (C) 2018 Stephen F. Norledge and Alces Software Ltd.


### PR DESCRIPTION
Update how the forge API has been set. It will now always append the version number to the the `api_url` implicitly. Also release notes have been added to how to update the `forge-cli`.