### PR TITLE
Allow install specific configuration files

### DIFF
--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '0.2.0'
+        program :version, '1.0.0'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/cli_utils.rb
+++ b/lib/alces/forge/cli_utils.rb
@@ -84,7 +84,11 @@ module Alces
             unless status.success?
               cmd_seperator = (cmd.include?("\n") ? "\n" : ' && ')
               raise ShellException.new <<-EOF
-The following command exited with status: #{status}
+The following shell command exited with a non-zero status
+PID: #{status.pid}
+STATUS: #{status.exitstatus}
+---------------------------------------------------
+COMMAND:
 cd #{working_dir}#{cmd_seperator}#{cmd}
 ---------------------------------------------------
 STDOUT:

--- a/lib/alces/forge/cli_utils.rb
+++ b/lib/alces/forge/cli_utils.rb
@@ -82,9 +82,10 @@ module Alces
             write_logs(working_dir, cmd, stdout, stderr)
 
             unless status.success?
+              cmd_seperator = (cmd.include?("\n") ? "\n" : ' && ')
               raise ShellException.new <<-EOF
 The following command exited with status: #{status}
-cd #{working_dir} && #{cmd}
+cd #{working_dir}#{cmd_seperator}#{cmd}
 ---------------------------------------------------
 STDOUT:
 #{stdout}

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -45,12 +45,14 @@ module Alces
 
         private
 
+        DATA_ROOT = (ENV['FL_ROOT'] || ENV['cw_ROOT'])
+
         DEFAULT_CONFIG = {
             default_user: 'alces',
-            package_cache_dir: "#{ENV['FL_ROOT']}/var/forge/cache/packages"
+            package_cache_dir: "#{DATA_ROOT}/var/forge/cache/packages"
         }
 
-        CONFIG_DIRECTORY = "#{ENV['FL_ROOT']}/etc/forge"
+        CONFIG_DIRECTORY = "#{DATA_ROOT}/etc/forge"
         CONFIG_FILE_PATH = "#{CONFIG_DIRECTORY}/config.yml"
 
         def config

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -46,15 +46,15 @@ module Alces
         private
 
         DATA_ROOT = (ENV['FL_ROOT'] || ENV['cw_ROOT'] || '/')
+        CONFIG_DIRECTORY = File.join(DATA_ROOT, 'etc/forge')
+        CONFIG_FILE_PATH = File.join(CONFIG_DIRECTORY, 'config.yml')
 
         DEFAULT_CONFIG = {
             default_user: 'alces',
             package_cache_dir: File.join(DATA_ROOT,
-                                         'var/forge/cache/packages')
+                                         'var/forge/cache/packages'),
+            install_configs: File.join(CONFIG_DIRECTORY, 'install')
         }
-
-        CONFIG_DIRECTORY = File.join(DATA_ROOT, 'etc/forge')
-        CONFIG_FILE_PATH = File.join(CONFIG_DIRECTORY, 'config.yml')
 
         def config
           @config ||= DEFAULT_CONFIG.dup.tap { |cfg|

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -49,11 +49,12 @@ module Alces
 
         DEFAULT_CONFIG = {
             default_user: 'alces',
-            package_cache_dir: "#{DATA_ROOT}/var/forge/cache/packages"
+            package_cache_dir: File.join(DATA_ROOT,
+                                         'var/forge/cache/packages')
         }
 
-        CONFIG_DIRECTORY = "#{DATA_ROOT}/etc/forge"
-        CONFIG_FILE_PATH = "#{CONFIG_DIRECTORY}/config.yml"
+        CONFIG_DIRECTORY = File.join(DATA_ROOT, 'etc/forge')
+        CONFIG_FILE_PATH = File.join(CONFIG_DIRECTORY, 'config.yml')
 
         def config
           @config ||= DEFAULT_CONFIG.dup.tap { |cfg|

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -53,7 +53,7 @@ module Alces
             default_user: 'alces',
             package_cache_dir: File.join(DATA_ROOT,
                                          'var/forge/cache/packages'),
-            install_configs: File.join(CONFIG_DIRECTORY, 'install')
+            install_config_dir: File.join(CONFIG_DIRECTORY, 'install')
         }
 
         def config

--- a/lib/alces/forge/config.rb
+++ b/lib/alces/forge/config.rb
@@ -45,7 +45,7 @@ module Alces
 
         private
 
-        DATA_ROOT = (ENV['FL_ROOT'] || ENV['cw_ROOT'])
+        DATA_ROOT = (ENV['FL_ROOT'] || ENV['cw_ROOT'] || '/')
 
         DEFAULT_CONFIG = {
             default_user: 'alces',

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -72,6 +72,11 @@ module Alces
         File.chmod(0700, File.join(@extracted_dir, 'install.sh'))
         cmd = <<-COMMAND
 set -e
+if [ -f "#{install_config_path}" ]; then
+  set -a
+  source #{install_config_path}
+  set +a
+fi
 source ./install.sh
 COMMAND
         shell(cmd, @extracted_dir)

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -76,6 +76,9 @@ if [ -f "#{install_config_path}" ]; then
   set -a
   source #{install_config_path}
   set +a
+  echo 'Sourced Config: #{install_config_path}'
+else
+  echo 'No Config: #{install_config_path}'
 fi
 source ./install.sh
 COMMAND

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -90,9 +90,16 @@ COMMAND
         @local_file = local_file
       end
 
+      def username
+        @metadata.username || 'unknown-user'
+      end
+
+      def name
+        @metadata.name || (raise 'Missing package name')
+      end
+
       def download_cache_path
-        username = @metadata.username || 'Unknown Package'
-        File.join(Config.package_cache_dir, username, @metadata.name)
+        File.join(Config.package_cache_dir, username, name)
       end
 
       def download_cache_file

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -70,8 +70,6 @@ module Alces
         extract unless @extracted_dir && Dir.exists?(@extracted_dir)
 
         File.chmod(0700, File.join(@extracted_dir, 'install.sh'))
-        # Strictly enforce all install scripts commands exiting with 0
-        # This can be manually turned off in the script with `set +e`
         cmd = <<-COMMAND
 set -e
 source ./install.sh

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -72,7 +72,11 @@ module Alces
         File.chmod(0700, File.join(@extracted_dir, 'install.sh'))
         # Strictly enforce all install scripts commands exiting with 0
         # This can be manually turned off in the script with `set +e`
-        shell('set -e; source ./install.sh', @extracted_dir)
+        cmd = <<-COMMAND
+set -e
+source ./install.sh
+COMMAND
+        shell(cmd, @extracted_dir)
       end
 
       def clean_up

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -104,7 +104,7 @@ COMMAND
       end
 
       def install_config_path
-        File.join(Config.install_config_dir, username, name)
+        File.join(Config.install_config_dir, username, name + '.rc')
       end
 
       def download_cache_path

--- a/lib/alces/forge/package_file.rb
+++ b/lib/alces/forge/package_file.rb
@@ -98,6 +98,10 @@ COMMAND
         @metadata.name || (raise 'Missing package name')
       end
 
+      def install_config_path
+        File.join(Config.install_config_dir, username, name)
+      end
+
       def download_cache_path
         File.join(Config.package_cache_dir, username, name)
       end


### PR DESCRIPTION
The first few commits of this PR clean up the use of constants within the `Config` class

At the end of the package install process, the packages `install.sh` file is sourced. Immediately before this, a new package specific config file is sourced. This allows for install specific environment variables to be set in the config and retrieved by the installer.

The config files are located at (by default):
```
$FL_ROOT/etc/forge/install/<username>/<package-name>.rc
```

All variables defined within the config are implicitly exported to the environment. This removes the need for `export` within the config script. This is turned off for the `install.sh` still needs to manually export its variables.