### PR TITLE
Fix install version dependency bug

### DIFF
--- a/lib/alces/forge/cli.rb
+++ b/lib/alces/forge/cli.rb
@@ -12,7 +12,7 @@ module Alces
 
       def run
         program :name, 'forge'
-        program :version, '1.0.0'
+        program :version, '1.0.1'
         program :description, 'Alces Flight Forge CLI'
 
         command :search do |c|

--- a/lib/alces/forge/commands/install.rb
+++ b/lib/alces/forge/commands/install.rb
@@ -37,7 +37,9 @@ module Alces
 
           package_files = []
 
-          dep_packages = to_install.reject { |p| (Registry.installed?(p) && !options.reinstall) || p == metadata }.map { |p| p.package_path }
+          dep_packages = to_install.reject do |p|
+            (Registry.installed?(p) && !options.reinstall) || p == metadata
+          end.map { |p| p.package_path }
           say "Installing for dependencies: #{dep_packages.join(', ')}" unless dep_packages.empty?
 
           to_install.each do |candidate|

--- a/lib/alces/forge/commands/install.rb
+++ b/lib/alces/forge/commands/install.rb
@@ -46,38 +46,34 @@ module Alces
           say "Installing for dependencies: #{dep_packages.join(', ')}" unless dep_packages.empty?
 
           to_install.each do |candidate|
+            package_file = do_with_spinner "Downloading #{candidate.package_path}" do
+              PackageFile.for(candidate).tap { |pf|
+                package_files << pf
+                # We ensure the package file is downloaded and cached regardless of whether we are about to use it
+                # immediately to install onto the master node.
+                unless pf.cached? && !options.reinstall
+                  pf.download
+                end
+              }
+            end
 
-            if !Registry.installed?(candidate) || options.reinstall
+            if should_install_on_compute_nodes(options)
+              Registry.mark(candidate, :compute)
+              say 'Package marked for installation on compute nodes.'
+            end
 
-              package_file = do_with_spinner "Downloading #{candidate.package_path}" do
-                PackageFile.for(candidate).tap { |pf|
-                  package_files << pf
-                  # We ensure the package file is downloaded and cached regardless of whether we are about to use it
-                  # immediately to install onto the master node.
-                  unless pf.cached? && !options.reinstall
-                    pf.download
-                  end
-                }
+            if should_install_here(options)
+              Registry.mark(candidate, :master)
+
+              do_with_spinner "Extracting #{candidate.package_path}" do
+                package_file.extract
               end
 
-              if should_install_on_compute_nodes(options)
-                Registry.mark(candidate, :compute)
-                say 'Package marked for installation on compute nodes.'
+              do_with_spinner "Installing #{candidate.package_path}" do
+                package_file.install
               end
 
-              if should_install_here(options)
-                Registry.mark(candidate, :master)
-
-                  do_with_spinner "Extracting #{candidate.package_path}" do
-                    package_file.extract
-                  end
-
-                  do_with_spinner "Installing #{candidate.package_path}" do
-                    package_file.install
-                  end
-
-                  Registry.set_installed(candidate)
-              end
+              Registry.set_installed(candidate)
             end
           end
         rescue Errors::NoSuchPackageException => e

--- a/lib/alces/forge/commands/install.rb
+++ b/lib/alces/forge/commands/install.rb
@@ -33,13 +33,16 @@ module Alces
 
           to_install = do_with_spinner 'Resolving dependencies' do
             Dependencies.resolve(api, metadata)
+                        .select do |package|
+                          next true if options.reinstall
+                          !Registry.installed?(package)
+                        end
           end
 
           package_files = []
 
-          dep_packages = to_install.reject do |p|
-            (Registry.installed?(p) && !options.reinstall) || p == metadata
-          end.map { |p| p.package_path }
+          dep_packages = to_install.reject(&:last?)
+                                   .map { |p| p.package_path }
           say "Installing for dependencies: #{dep_packages.join(', ')}" unless dep_packages.empty?
 
           to_install.each do |candidate|

--- a/lib/alces/forge/dependencies.rb
+++ b/lib/alces/forge/dependencies.rb
@@ -16,9 +16,9 @@ module Alces
 
         def resolve_level(api, metadata, level=0)
 
-          deps_metadata = metadata.dependencies.map do |dep|
-            package = Registry.installed_version(dep)
-            package ||= PackageMetadata.load_from_path(api, dep)
+          deps_metadata = metadata.dependencies.map do |raw_dep|
+            dep = Registry.installed_version(raw_dep) || raw_dep
+            PackageMetadata.load_from_path(api, dep)
           end
 
           deps = deps_metadata.map do |dep|

--- a/lib/alces/forge/dependencies.rb
+++ b/lib/alces/forge/dependencies.rb
@@ -1,4 +1,5 @@
 require 'alces/forge/errors'
+require 'alces/forge/registry'
 
 module Alces
   module Forge
@@ -16,7 +17,8 @@ module Alces
         def resolve_level(api, metadata, level=0)
 
           deps_metadata = metadata.dependencies.map do |dep|
-            PackageMetadata.load_from_path(api, dep)
+            package = Registry.installed_version(dep)
+            package ||= PackageMetadata.load_from_path(api, dep)
           end
 
           deps = deps_metadata.map do |dep|

--- a/lib/alces/forge/dependencies.rb
+++ b/lib/alces/forge/dependencies.rb
@@ -6,21 +6,22 @@ module Alces
       class << self
 
         def resolve(api, metadata)
-          resolve_level(api, metadata)
-              .sort_by {|p| -p[:level]}
-              .map {|p| p[:package]}
-              .uniq { |p| p.id }
+          resolve_level(api, metadata).sort_by {|p| -p[:level]}
+                                      .map {|p| p[:package]}
+                                      .uniq { |p| p.id }
         end
 
         private
 
         def resolve_level(api, metadata, level=0)
 
-          deps_metadata = metadata.dependencies.map { |dep|
+          deps_metadata = metadata.dependencies.map do |dep|
             PackageMetadata.load_from_path(api, dep)
-          }
+          end
 
-          deps = deps_metadata.map { |dep| resolve_level(api, dep, level + 1)}
+          deps = deps_metadata.map do |dep|
+            resolve_level(api, dep, level + 1)
+          end
 
           deps.flatten << {level: level, package: metadata}
         end

--- a/lib/alces/forge/package_metadata.rb
+++ b/lib/alces/forge/package_metadata.rb
@@ -65,8 +65,8 @@ module Alces
         end
       end
 
-      def package_path
-        "#{username}/#{name}/#{version}"
+      def package_path(include_version: true)
+        "#{username}/#{name}#{'/' + version if include_version}"
       end
 
       def id

--- a/lib/alces/forge/registry.rb
+++ b/lib/alces/forge/registry.rb
@@ -25,6 +25,9 @@ module Alces
           installed_packages.include?(metadata.package_path)
         end
 
+        def installed_version(package_name)
+        end
+
         def set_installed(metadata)
           unless installed_packages.include?(metadata.package_path)
             installed_packages << metadata.package_path

--- a/lib/alces/forge/registry.rb
+++ b/lib/alces/forge/registry.rb
@@ -26,6 +26,9 @@ module Alces
         end
 
         def installed_version(package_name)
+          installed_packages.find do |candidate|
+            /#{package_name}\/*/.match?(candidate)
+          end
         end
 
         def set_installed(metadata)

--- a/lib/alces/forge/registry.rb
+++ b/lib/alces/forge/registry.rb
@@ -26,16 +26,14 @@ module Alces
         end
 
         def installed_version(package_name)
-          installed_packages.find do |candidate|
-            /#{package_name}\/*/.match?(candidate)
-          end
+          installed_packages.find(&match_proc(package_name))
         end
 
         def set_installed(metadata)
-          unless installed_packages.include?(metadata.package_path)
-            installed_packages << metadata.package_path
-            save_local
-          end
+          package_name = metadata.package_path(include_version: false)
+          installed_packages.reject!(&match_proc(package_name))
+          installed_packages << metadata.package_path
+          save_local
         end
 
         def marked_packages(node_type)
@@ -53,6 +51,12 @@ module Alces
         end
 
         private
+
+        def match_proc(package_name)
+          Proc.new do |candidate|
+            /#{package_name}\/*/.match?(candidate)
+          end
+        end
 
         def master
           @master ||= load(MASTER_REGISTRY_PATH, DEFAULT_MASTER_REGISTRY)


### PR DESCRIPTION
Due to the dependency resolution, packages may be installed multiple times. To prevent this, a list of installed packages is cached. The cache is version number specific, so a different version is considered a different package.

The dependency resolution previously always selected the latest version. This creates a bug where a previously installed package will overridden by the newer dependency.

To prevent this, the dependency resolution now prefers the installed version